### PR TITLE
Fixing 404'd link

### DIFF
--- a/v1.x/docs/getting_started.html
+++ b/v1.x/docs/getting_started.html
@@ -75,7 +75,7 @@
                   </ul>
                 </p>
 
-                <pre class="code">
+                <pre class="code"> <!-- should be `new Phylocanvas` for current checkouts -->
 var phylocanvas = new PhyloCanvas.Tree(<i>div</i>, <i>[config object]</i>); // initialize your tree viewer
 phylocanvas.load(<i>Newick / Nexus</i>); // load your tree file</pre>
               <p>
@@ -86,7 +86,7 @@ phylocanvas.load(<i>Newick / Nexus</i>); // load your tree file</pre>
                   <dt><i>config object</i></dt>
                   <dd>Optional parameters used to configure the tree <a href="api_ref.html">See more config options</a></dd>
                   <dt><i>Newick</i></dt>
-                  <dd> A string or a file that contains a Newick or Nexus formatted tree <a target="_blank" href="docs/data/simple_tree.nwk">Sample Newick</a></dd>
+                  <dd> A string or a file that contains a Newick or Nexus formatted tree <a target="_blank" href="data/simple_tree.nwk">Sample Newick</a></dd>
                 </dl>
               </p>
 


### PR DESCRIPTION
I know this is for an old version of the documentation, but the page at http://phylocanvas.org/v1.x/docs/getting_started.html gives a 404.
